### PR TITLE
Add automated tests for kvm.ps1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Pester PowerShell Unit Test Framework is fetched from Git when needed
+# Things related to tests
 .pester/
 .testwork/
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Pester PowerShell Unit Test Framework is fetched from Git when needed
+.pester/
+.testwork/
+
 [Oo]bj/
 [Bb]in/
 TestResults/

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetvnext/api/v2" />
+    <add key="AspNetVNext" value="https://www.myget.org/F/aspnetvnext/" />
     <add key="NuGet.org" value="https://nuget.org/api/v2/" />
   </packageSources>
 </configuration>

--- a/makefile.shade
+++ b/makefile.shade
@@ -25,4 +25,4 @@ var ARTIFACTS_DIR = '${Path.Combine(ROOT, "artifacts")}'
     }
 
 #run-ps1-tests target='test' if='!IsLinux'
-	exec program='powershell' commandline='-ExecutionPolicy RemoteSigned -NoProfile -NoLogo -Command & "${Path.Combine(TEST_DIR, "ps1", "Run-Tests.ps1")} -OutputFile ${Path.Combine(ARTIFACTS_DIR, "ps1tests.nunit.xml")} -OutputFormat NUnitXml ${IsTeamCity?"-TeamCity":""}'
+	exec program='powershell' commandline='-ExecutionPolicy RemoteSigned -NoProfile -NoLogo -Command & "${Path.Combine(TEST_DIR, "ps1", "Run-Tests.ps1")} ${IsTeamCity?"-TeamCity":""}'

--- a/makefile.shade
+++ b/makefile.shade
@@ -1,6 +1,7 @@
 use assembly="System.Xml.Linq, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
 use assembly="System.IO.Compression.FileSystem, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"
 use import="Environment"
+use import="BuildEnv"
 
 var PRODUCT_VERSION = '1.0.0'
 var AUTHORS='Microsoft Open Technologies, Inc.'
@@ -9,6 +10,7 @@ use-standard-lifecycle
 
 var ROOT = '${Directory.GetCurrentDirectory()}'
 var SOURCE_DIR = '${Path.Combine(ROOT, "src")}'
+var TEST_DIR = '${Path.Combine(ROOT, "test")}'
 var ARTIFACTS_DIR = '${Path.Combine(ROOT, "artifacts")}'
 
 #copy-kvm target='compile'
@@ -21,3 +23,6 @@ var ARTIFACTS_DIR = '${Path.Combine(ROOT, "artifacts")}'
     update-file updateFile='${Path.Combine(ARTIFACTS_DIR, "kvm.sh")}' @{
         updateText = updateText.Replace("{{BUILD_NUMBER}}", Environment.GetEnvironmentVariable("BUILD_NUMBER"));
     }
+
+#run-ps1-tests target='test' if='!IsLinux'
+	exec program='powershell' commandline='-ExecutionPolicy RemoteSigned -NoProfile -NoLogo -Command & "${Path.Combine(TEST_DIR, "ps1", "Run-Tests.ps1")} ${IsTeamCity ? "-TeamCity" : "-Fast"}'

--- a/makefile.shade
+++ b/makefile.shade
@@ -25,4 +25,4 @@ var ARTIFACTS_DIR = '${Path.Combine(ROOT, "artifacts")}'
     }
 
 #run-ps1-tests target='test' if='!IsLinux'
-	exec program='powershell' commandline='-ExecutionPolicy RemoteSigned -NoProfile -NoLogo -Command & "${Path.Combine(TEST_DIR, "ps1", "Run-Tests.ps1")} -OutputFile ${Path.Combine(ARTIFACTS_DIR, "ps1tests.nunit.xml")} -OutputFormat NUnitXml"'
+	exec program='powershell' commandline='-ExecutionPolicy RemoteSigned -NoProfile -NoLogo -Command & "${Path.Combine(TEST_DIR, "ps1", "Run-Tests.ps1")} -OutputFile ${Path.Combine(ARTIFACTS_DIR, "ps1tests.nunit.xml")} -OutputFormat NUnitXml ${IsTeamCity?"-TeamCity":""}'

--- a/makefile.shade
+++ b/makefile.shade
@@ -25,4 +25,4 @@ var ARTIFACTS_DIR = '${Path.Combine(ROOT, "artifacts")}'
     }
 
 #run-ps1-tests target='test' if='!IsLinux'
-	exec program='powershell' commandline='-ExecutionPolicy RemoteSigned -NoProfile -NoLogo -Command & "${Path.Combine(TEST_DIR, "ps1", "Run-Tests.ps1")} ${IsTeamCity ? "-TeamCity" : "-Fast"}'
+	exec program='powershell' commandline='-ExecutionPolicy RemoteSigned -NoProfile -NoLogo -Command & "${Path.Combine(TEST_DIR, "ps1", "Run-Tests.ps1")} ${IsTeamCity ? "-TeamCity" : ""}'

--- a/makefile.shade
+++ b/makefile.shade
@@ -25,4 +25,4 @@ var ARTIFACTS_DIR = '${Path.Combine(ROOT, "artifacts")}'
     }
 
 #run-ps1-tests target='test' if='!IsLinux'
-	exec program='powershell' commandline='-ExecutionPolicy RemoteSigned -NoProfile -NoLogo -Command & "${Path.Combine(TEST_DIR, "ps1", "Run-Tests.ps1")} ${IsTeamCity ? "-TeamCity" : ""}'
+	exec program='powershell' commandline='-ExecutionPolicy RemoteSigned -NoProfile -NoLogo -Command & "${Path.Combine(TEST_DIR, "ps1", "Run-Tests.ps1")} -OutputFile ${Path.Combine(ARTIFACTS_DIR, "ps1tests.nunit.xml")} -OutputFormat NUnitXml"'

--- a/src/kvm.ps1
+++ b/src/kvm.ps1
@@ -207,7 +207,6 @@ param(
 
   $wc = New-Object System.Net.WebClient
   Add-Proxy-If-Specified($wc)
-  Write-Debug "DownloadString: $url"
   [xml]$xml = $wc.DownloadString($url)
 
   $version = Select-Xml "//d:Version" -Namespace @{d='http://schemas.microsoft.com/ado/2007/08/dataservices'} $xml
@@ -254,7 +253,6 @@ param(
 
   $wc = New-Object System.Net.WebClient
   Add-Proxy-If-Specified($wc)
-  Write-Debug "DownloadFile: $url, $tempKreFile"
   $wc.DownloadFile($url, $tempKreFile)
 
   Do-Kvm-Unpack $tempKreFile $kreTempDownload
@@ -772,8 +770,6 @@ function Validate-And-Santitize-Switches()
     }
   }
 
-  Write-Debug "Runtime=$selectedRuntime"
-  Write-Debug "Arch=$selectedArch"
 }
 
 $script:capturedOut = @()

--- a/src/kvm.ps1
+++ b/src/kvm.ps1
@@ -561,6 +561,7 @@ param(
   $aliasFilePath=$userKrePath + "\alias\" + $name + ".txt"
   if (!(Test-Path $aliasFilePath)) {
     Console-Write "Alias '$name' does not exist"
+    $script:exitCode = 1 # Return non-zero exit code for scripting
   } else {
     $aliasValue = (Get-Content ($userKrePath + "\alias\" + $name + ".txt"))
     Console-Write "Alias '$name' is set to $aliasValue" 
@@ -830,7 +831,7 @@ param(
   }
 }
 
-$exitCode = 0
+$script:exitCode = 0
 try {
   Validate-And-Santitize-Switches
   if ($Global) {
@@ -861,7 +862,7 @@ try {
 catch {
   Console-Write-Error $_
   Console-Write "Type 'kvm help' for help on how to use kvm."
-  $exitCode = -1
+  $script:exitCode = -1
 }
 if ($Wait) {
   Console-Write "Press any key to continue ..."
@@ -873,4 +874,4 @@ if($OutputVariable) {
   Set-Variable $OutputVariable $script:capturedOut -Scope 1
 }
 
-exit $exitCode
+exit $script:exitCode

--- a/src/kvm.ps1
+++ b/src/kvm.ps1
@@ -7,6 +7,7 @@ param(
   [alias("p")][switch] $Persistent = $false,
   [alias("f")][switch] $Force = $false,
   [alias("r")][string] $Runtime,
+  [alias("arch")][string] $Architecture,
   [switch] $X86 = $false,
   [switch] $Amd64 = $false,
   #deprecated
@@ -20,16 +21,25 @@ param(
   [string] $Alias = $null,
   [switch] $NoNative = $false,
   [parameter(Position=1, ValueFromRemainingArguments=$true)]
-  [string[]]$Args=@()
+  [string[]]$Args=@(),
+  [switch] $Quiet,
+  [string] $OutputVariable,
+  [switch] $AssumeElevated
 )
 
 $selectedArch=$null;
 $defaultArch="x86"
 $selectedRuntime=$null
 $defaultRuntime="CLR"
-$userKrePath = $env:USERPROFILE + "\.kre"
+
+# Get or calculate userKrePath
+$userKrePath = $env:USER_KRE_PATH
+if(!$userKrePath) { $userKrePath = $env:USERPROFILE + "\.kre" }
 $userKrePackages = $userKrePath + "\packages"
-$globalKrePath = $env:ProgramFiles + "\KRE"
+
+# Get or calculate globalKrePath
+$globalKrePath = $env:GLOBAL_KRE_PATH
+if(!$globalKrePath) { $globalKrePath = $env:ProgramFiles + "\KRE" }
 $globalKrePackages = $globalKrePath + "\packages"
 $feed = $env:KRE_FEED
 
@@ -44,6 +54,8 @@ if (!$feed)
 {
     $feed = "https://www.myget.org/F/aspnetvnext/api/v2";
 }
+
+$feed = $feed.TrimEnd("/")
 
 $scriptPath = $myInvocation.MyCommand.Definition
 
@@ -195,6 +207,7 @@ param(
 
   $wc = New-Object System.Net.WebClient
   Add-Proxy-If-Specified($wc)
+  Write-Debug "DownloadString: $url"
   [xml]$xml = $wc.DownloadString($url)
 
   $version = Select-Xml "//d:Version" -Namespace @{d='http://schemas.microsoft.com/ado/2007/08/dataservices'} $xml
@@ -241,6 +254,7 @@ param(
 
   $wc = New-Object System.Net.WebClient
   Add-Proxy-If-Specified($wc)
+  Write-Debug "DownloadFile: $url, $tempKreFile"
   $wc.DownloadFile($url, $tempKreFile)
 
   Do-Kvm-Unpack $tempKreFile $kreTempDownload
@@ -696,6 +710,10 @@ SET "PATH=$newPath"
 }
 
 function Needs-Elevation() {
+  if($AssumeElevated) {
+    return $false
+  }
+
   $user = [Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()
   $elevated = $user.IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
   return -NOT $elevated
@@ -735,33 +753,52 @@ function Validate-And-Santitize-Switches()
     Set-Variable -Name "selectedRuntime" -Value "svrc50" -Scope Script
   }
 
-  if ($X64) {
-    Console-Write "Warning: -x64 is deprecated, use -amd64 for new packages."
-    Set-Variable -Name "selectedArch" -Value "x64" -Scope Script
-  } elseif ($Amd64) {
-    Set-Variable -Name "selectedArch" -Value "amd64" -Scope Script
-  } elseif ($X86) {
-    Set-Variable -Name "selectedArch" -Value "x86" -Scope Script
+  if($Architecture) {
+    $validArchitectures = "amd64", "x86"
+    $match = $validArchitectures | ? { $_ -like $Architecture } | Select -First 1
+    if(!$match) {throw "'$architecture' is not a valid architecture"}
+    Set-Variable -Name "selectedArch" -Value $match -Scope Script
   }
+  else {
+    if ($X64) {
+      Console-Write "Warning: -x64 is deprecated, use -amd64 for new packages."
+      Set-Variable -Name "selectedArch" -Value "x64" -Scope Script
+    } elseif ($Amd64) {
+      Set-Variable -Name "selectedArch" -Value "amd64" -Scope Script
+    } elseif ($X86) {
+      Set-Variable -Name "selectedArch" -Value "x86" -Scope Script
+    }
+  }
+
+  Write-Debug "Runtime=$selectedRuntime"
+  Write-Debug "Arch=$selectedArch"
 }
 
+$script:capturedOut = @()
 function Console-Write() {
 param(
   [Parameter(ValueFromPipeline=$true)]
   [string] $message
 )
-  if ($useHostOutputMethods) {
-    try {
-      Write-Host $message
-    }
-    catch {
-      $script:useHostOutputMethods = $false
-      Console-Write $message
-    }
+  if($OutputVariable) {
+    # Update the capture output
+    $script:capturedOut += @($message)
   }
-  else {
-    [Console]::WriteLine($message)
-  }  
+
+  if(!$Quiet) {
+    if ($useHostOutputMethods) {
+      try {
+        Write-Host $message
+      }
+      catch {
+        $script:useHostOutputMethods = $false
+        Console-Write $message
+      }
+    }
+    else {
+      [Console]::WriteLine($message)
+    }  
+  }
 }
 
 function Console-Write-Error() {
@@ -829,6 +866,11 @@ catch {
 if ($Wait) {
   Console-Write "Press any key to continue ..."
   $x = $host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown,AllowCtrlC")
+}
+
+# If the user specified an output variable, push the value up to the parent scope
+if($OutputVariable) {
+  Set-Variable $OutputVariable $script:capturedOut -Scope 1
 }
 
 exit $exitCode

--- a/src/kvm.ps1
+++ b/src/kvm.ps1
@@ -591,6 +591,7 @@ param(
       Remove-Item -literalPath $aliasPath
   } else {
       Console-Write "Cannot remove alias, '$name' is not a valid alias name"
+      $script:exitCode = 1 # Return non-zero exit code for scripting
   }
 }
 

--- a/test/apps/HelloK/HelloK.kproj
+++ b/test/apps/HelloK/HelloK.kproj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="__ToolsVersion__" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>0ef87869-3442-40aa-a0e6-089cd385f7d0</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x86'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x86'" Label="Configuration">
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\AspNet\Microsoft.Web.AspNet.targets" Condition="'$(VSToolsPath)' != ''" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties project_1json__JSONSchema="http://www.asp.net/media/4878834/project.json" />
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/test/apps/HelloK/HelloK.sln
+++ b/test/apps/HelloK/HelloK.sln
@@ -1,0 +1,22 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.22410.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "HelloK", "HelloK.kproj", "{0EF87869-3442-40AA-A0E6-089CD385F7D0}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0EF87869-3442-40AA-A0E6-089CD385F7D0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0EF87869-3442-40AA-A0E6-089CD385F7D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0EF87869-3442-40AA-A0E6-089CD385F7D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0EF87869-3442-40AA-A0E6-089CD385F7D0}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/test/apps/HelloK/Program.cs
+++ b/test/apps/HelloK/Program.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Diagnostics;
+using Microsoft.Framework.Runtime;
+using Microsoft.Framework.Runtime.Common.CommandLine;
+
+namespace HelloK {
+    public class Program {
+        private readonly IApplicationEnvironment _env;
+        public Program(IApplicationEnvironment env) {
+            _env = env;
+        }
+
+        private string GetUnameValue(string arg) {
+            var psi = new ProcessStartInfo("uname", "-" + arg);
+            psi.UseShellExecute = false;
+            psi.RedirectStandardOutput = true;
+            var p = Process.Start(psi);
+            var ret = p.StandardOutput.ReadToEnd().Trim();
+            p.WaitForExit();
+            return ret;
+        }
+
+        private string GetSwVersValue(string arg) {
+            var psi = new ProcessStartInfo("sw_vers", "-" + arg);
+            psi.UseShellExecute = false;
+            psi.RedirectStandardOutput = true;
+            var p = Process.Start(psi);
+            var ret = p.StandardOutput.ReadToEnd().Trim();
+            p.WaitForExit();
+            return ret;
+        }
+
+#if !ASPNETCORE50
+        private string GetPlatform() {
+            if(Environment.OSVersion.Platform == PlatformID.Unix) {
+                var kern = GetUnameValue("s");
+                var kernVer = GetUnameValue("r");
+                if(string.Equals(kern, "Darwin", StringComparison.OrdinalIgnoreCase)) {
+                    var name = GetSwVersValue("productName");
+                    var ver = GetSwVersValue("productVersion");
+                    var build = GetSwVersValue("buildVersion");
+                    return name + " " + ver + " Build " + build + " (" + kern + " " + kernVer + ")";
+                } else {
+                    return kern + " " + kernVer;
+                }
+            } else {
+                return Environment.OSVersion.VersionString;
+            }
+        }
+#endif
+
+        public int Main(string[] args) {
+            var art =
+                "\x1b[33m   ___   _______  \x1b[34m  _  ____________" + Environment.NewLine +
+                "\x1b[33m  / _ | / __/ _ \\ \x1b[34m / |/ / __/_  __/" + Environment.NewLine +
+                "\x1b[33m / __ |_\\ \\/ ___/ \x1b[34m/    / _/  / /   " + Environment.NewLine +
+                "\x1b[33m/_/ |_/___/_/  \x1b[37m(_)\x1b[34m_/|_/___/ /_/    \x1b[39m";
+
+            AnsiConsole.Output.WriteLine(art);
+            AnsiConsole.Output.WriteLine("K is sane!");
+            AnsiConsole.Output.WriteLine("\x1b[30mRuntime Framework:    \x1b[39m " + _env.RuntimeFramework.ToString());
+#if ASPNETCORE50
+            AnsiConsole.Output.WriteLine("\x1b[30mRuntime:              \x1b[39m Microsoft CoreCLR");
+#else
+            // Platform detection
+            var platform = GetPlatform();
+
+            AnsiConsole.Output.WriteLine("\x1b[30mRuntime:              \x1b[39m " + (Type.GetType("Mono.Runtime") != null ? "Mono CLR" : "Microsoft CLR"));
+            AnsiConsole.Output.WriteLine("\x1b[30mRuntime Version:      \x1b[39m " + Environment.Version.ToString());
+            AnsiConsole.Output.WriteLine("\x1b[30mOS:                   \x1b[39m " + platform);
+            AnsiConsole.Output.WriteLine("\x1b[30mMachine Name:         \x1b[39m " + Environment.MachineName ?? "<null>");
+            AnsiConsole.Output.WriteLine("\x1b[30mUser Name:            \x1b[39m " + Environment.UserName ?? "<null>");
+            AnsiConsole.Output.WriteLine("\x1b[30mSystem Directory:     \x1b[39m " + Environment.SystemDirectory ?? "<null>");
+            AnsiConsole.Output.WriteLine("\x1b[30mCurrent Directory:    \x1b[39m " + Environment.CurrentDirectory ?? "<null>");
+#endif
+            AnsiConsole.Output.WriteLine("");
+            AnsiConsole.Output.WriteLine(
+                "\x1b[1m" +
+                "\x1b[30mA" + 
+                "\x1b[31mN" + 
+                "\x1b[32mS" +
+                "\x1b[33mI" + " " +
+                "\x1b[34mR" +
+                "\x1b[35ma" +
+                "\x1b[36mi" +
+                "\x1b[37mn" +
+                "\x1b[38mb" +
+                "\x1b[22m" +
+                "\x1b[30mo" +
+                "\x1b[32mw" +
+                "\x1b[33m!" +
+                "\x1b[34m!" +
+                "\x1b[35m!" +
+                "\x1b[36m!" +
+                "\x1b[37m!" +
+                "\x1b[38m!" +
+                "\x1b[39m");
+
+            return 0;
+        }
+    }
+}

--- a/test/apps/HelloK/Program.cs
+++ b/test/apps/HelloK/Program.cs
@@ -10,45 +10,6 @@ namespace HelloK {
             _env = env;
         }
 
-        private string GetUnameValue(string arg) {
-            var psi = new ProcessStartInfo("uname", "-" + arg);
-            psi.UseShellExecute = false;
-            psi.RedirectStandardOutput = true;
-            var p = Process.Start(psi);
-            var ret = p.StandardOutput.ReadToEnd().Trim();
-            p.WaitForExit();
-            return ret;
-        }
-
-        private string GetSwVersValue(string arg) {
-            var psi = new ProcessStartInfo("sw_vers", "-" + arg);
-            psi.UseShellExecute = false;
-            psi.RedirectStandardOutput = true;
-            var p = Process.Start(psi);
-            var ret = p.StandardOutput.ReadToEnd().Trim();
-            p.WaitForExit();
-            return ret;
-        }
-
-#if !ASPNETCORE50
-        private string GetPlatform() {
-            if(Environment.OSVersion.Platform == PlatformID.Unix) {
-                var kern = GetUnameValue("s");
-                var kernVer = GetUnameValue("r");
-                if(string.Equals(kern, "Darwin", StringComparison.OrdinalIgnoreCase)) {
-                    var name = GetSwVersValue("productName");
-                    var ver = GetSwVersValue("productVersion");
-                    var build = GetSwVersValue("buildVersion");
-                    return name + " " + ver + " Build " + build + " (" + kern + " " + kernVer + ")";
-                } else {
-                    return kern + " " + kernVer;
-                }
-            } else {
-                return Environment.OSVersion.VersionString;
-            }
-        }
-#endif
-
         public int Main(string[] args) {
             var art =
                 "\x1b[33m   ___   _______  \x1b[34m  _  ____________" + Environment.NewLine +
@@ -98,5 +59,45 @@ namespace HelloK {
 
             return 0;
         }
+
+        private string GetUnameValue(string arg) {
+            var psi = new ProcessStartInfo("uname", "-" + arg);
+            psi.UseShellExecute = false;
+            psi.RedirectStandardOutput = true;
+            var p = Process.Start(psi);
+            var ret = p.StandardOutput.ReadToEnd().Trim();
+            p.WaitForExit();
+            return ret;
+        }
+
+        private string GetSwVersValue(string arg) {
+            var psi = new ProcessStartInfo("sw_vers", "-" + arg);
+            psi.UseShellExecute = false;
+            psi.RedirectStandardOutput = true;
+            var p = Process.Start(psi);
+            var ret = p.StandardOutput.ReadToEnd().Trim();
+            p.WaitForExit();
+            return ret;
+        }
+
+#if !ASPNETCORE50
+        private string GetPlatform() {
+            if(Environment.OSVersion.Platform == PlatformID.Unix) {
+                var kern = GetUnameValue("s");
+                var kernVer = GetUnameValue("r");
+                if(string.Equals(kern, "Darwin", StringComparison.OrdinalIgnoreCase)) {
+                    var name = GetSwVersValue("productName");
+                    var ver = GetSwVersValue("productVersion");
+                    var build = GetSwVersValue("buildVersion");
+                    return name + " " + ver + " Build " + build + " (" + kern + " " + kernVer + ")";
+                } else {
+                    return kern + " " + kernVer;
+                }
+            } else {
+                return Environment.OSVersion.VersionString;
+            }
+        }
+#endif
+       
     }
 }

--- a/test/apps/HelloK/project.json
+++ b/test/apps/HelloK/project.json
@@ -1,0 +1,22 @@
+{
+    "version": "0.0.1-*",
+    "description": "Quick app to exercise a few K things",
+    "dependencies": {
+        "Microsoft.Framework.Runtime.Interfaces": { "version": "1.0.0-*", "type": "build" },
+        "Microsoft.Framework.CommandLineUtils": { "version": "1.0.0-*", "type": "build" }
+    },
+    "commands": {
+        "run": "run"
+    },
+    "frameworks": {
+        "aspnet50": { },
+        "aspnetcore50": {
+            "dependencies": {
+                "System.Console": "4.0.0-*",
+                "System.Collections": "4.0.10-*",
+                "System.Diagnostics.Process": "4.0.0-*",
+                "System.Linq": "4.0.0-*"
+            }
+        }
+    }
+}

--- a/test/apps/README.md
+++ b/test/apps/README.md
@@ -1,0 +1,2 @@
+# Test Apps
+Sample K apps for testing KVM installations.

--- a/test/ps1/Run-Tests.ps1
+++ b/test/ps1/Run-Tests.ps1
@@ -49,6 +49,8 @@ param(
     [string]$TestWorkingDir = $null,
     [string]$TestAppsDir = $null,
     [Alias("Tags")][string]$Tag = $null,
+    [string]$OutputFile = $null,
+    [string]$OutputFormat = $null,
     [switch]$Quiet,
     [switch]$Debug,
     [switch]$TeamCity)

--- a/test/ps1/Run-Tests.ps1
+++ b/test/ps1/Run-Tests.ps1
@@ -41,8 +41,8 @@
 #>
 param(
     [string]$PesterPath = $null,
-    [string]$PesterRef = "anurse/teamcity",
-    [string]$PesterRepo = "https://github.com/anurse/Pester",
+    [string]$PesterRef = "master",
+    [string]$PesterRepo = "https://github.com/pester/Pester",
     [string]$TestsPath = $null,
     [string]$KvmPath = $null,
     [string]$TestName = $null,

--- a/test/ps1/Run-Tests.ps1
+++ b/test/ps1/Run-Tests.ps1
@@ -25,7 +25,8 @@ param(
     [switch]$Strict,
     [switch]$Quiet,
     [switch]$Fast,
-    [switch]$Debug)
+    [switch]$Debug,
+    [switch]$TeamCity)
 
 . "$PSScriptRoot\_Common.ps1"
 
@@ -45,4 +46,6 @@ $PSBoundParameters.Keys | ForEach-Object {
     }
 }
 
-& powershell -NoProfile -NoLogo -File "$PSScriptRoot\_Execute-Tests.ps1" @childArgs -RunningInNewPowershell
+& powershell -NoProfile -NoLogo -Command "& `"$PSScriptRoot\_Execute-Tests.ps1`" $childArgs -RunningInNewPowershell"
+
+exit $LASTEXITCODE

--- a/test/ps1/Run-Tests.ps1
+++ b/test/ps1/Run-Tests.ps1
@@ -4,13 +4,40 @@
     Runs the tests for kvm
 
 .PARAMETER PesterPath
-    The path to the root of the Pester (https://github.com/pester/Pester) module
+    The path to the root of the Pester (https://github.com/pester/Pester) module (optional)
 
 .PARAMETER PesterRef
-    A git ref (branch, tag or commit id) to check out in the pester repo
+    A git ref (branch, tag or commit id) to check out in the pester repo (optional)
 
 .PARAMETER PesterRepo
-    The repository to clone Pester from (defaults to https://github.com/pester/Pester)
+    The repository to clone Pester from (optional)
+
+.PARAMETER TestsPath
+    The path to the folder containing Tests to run (optional)
+
+.PARAMETER KvmPath
+    The path to the kvm.ps1 script to test (optional)
+
+.PARAMETER TestName
+    The name of a specific test to run (optional)
+
+.PARAMETER TestWorkingDir
+    The directory in which to place KREs downloaded during the tests (optional)
+
+.PARAMETER TestAppsDir
+    The directory in which test K apps live (optional)
+
+.PARAMETER Tag
+    Run only tests with the specified tag (optional)
+
+.PARAMETER Quiet
+    Output minimal console messages
+
+.PARAMETER Debug
+    Output extra console messages
+
+.PARAMETER TeamCity
+    Output TeamCity test outcome markers
 #>
 param(
     [string]$PesterPath = $null,
@@ -22,7 +49,6 @@ param(
     [string]$TestWorkingDir = $null,
     [string]$TestAppsDir = $null,
     [Alias("Tags")][string]$Tag = $null,
-    [switch]$Strict,
     [switch]$Quiet,
     [switch]$Debug,
     [switch]$TeamCity)
@@ -32,6 +58,7 @@ param(
 Write-Banner "Starting child shell"
 
 # Crappy that we have to duplicate things here...
+# Build a string that should basically match the argument string used to call us
 $childArgs = @()
 $PSBoundParameters.Keys | ForEach-Object {
     $key = $_
@@ -45,6 +72,7 @@ $PSBoundParameters.Keys | ForEach-Object {
     }
 }
 
+# Launch the script that will actually run the tests in a new shell
 & powershell -NoProfile -NoLogo -Command "& `"$PSScriptRoot\_Execute-Tests.ps1`" $childArgs -RunningInNewPowershell"
 
 exit $LASTEXITCODE

--- a/test/ps1/Run-Tests.ps1
+++ b/test/ps1/Run-Tests.ps1
@@ -1,0 +1,48 @@
+#Requires -Version 3
+<#
+.SYNOPSIS
+    Runs the tests for kvm
+
+.PARAMETER PesterPath
+    The path to the root of the Pester (https://github.com/pester/Pester) module
+
+.PARAMETER PesterRef
+    A git ref (branch, tag or commit id) to check out in the pester repo
+
+.PARAMETER PesterRepo
+    The repository to clone Pester from (defaults to https://github.com/pester/Pester)
+#>
+param(
+    [string]$PesterPath = $null,
+    [string]$PesterRef = "3.2.0",
+    [string]$PesterRepo = "https://github.com/pester/Pester",
+    [string]$TestsPath = $null,
+    [string]$KvmPath = $null,
+    [string]$TestName = $null,
+    [string]$TestWorkingDir = $null,
+    [string]$TestAppsDir = $null,
+    [Alias("Tags")][string]$Tag = $null,
+    [switch]$Strict,
+    [switch]$Quiet,
+    [switch]$Fast,
+    [switch]$Debug)
+
+. "$PSScriptRoot\_Common.ps1"
+
+Write-Banner "Starting child shell"
+
+# Crappy that we have to duplicate things here...
+$childArgs = @()
+$PSBoundParameters.Keys | ForEach-Object {
+    $key = $_
+    $value = $PSBoundParameters[$key]
+    if($value -is [switch]) {
+        if($value.IsPresent) {
+            $childArgs += @("-$key")
+        }
+    } else {
+        $childArgs += @("-$key",$value)
+    }
+}
+
+& powershell -NoProfile -NoLogo -File "$PSScriptRoot\_Execute-Tests.ps1" @childArgs -RunningInNewPowershell

--- a/test/ps1/Run-Tests.ps1
+++ b/test/ps1/Run-Tests.ps1
@@ -71,6 +71,8 @@ pushd $PesterPath
 git checkout $PesterRef 2>&1 | Write-CommandOutput "git"
 popd
 
+Write-Banner "Starting child shell to run"
+
 # Crappy that we have to duplicate things here...
 # Build a string that should basically match the argument string used to call us
 $childArgs = @()
@@ -87,7 +89,6 @@ $PSBoundParameters.Keys | ForEach-Object {
 }
 
 # Launch the script that will actually run the tests in a new shell
-Write-Banner "Starting new shell to run tests"
 & powershell -NoProfile -NoLogo -Command "& `"$PSScriptRoot\_Execute-Tests.ps1`" $childArgs -RunningInNewPowershell"
 
 exit $LASTEXITCODE

--- a/test/ps1/Run-Tests.ps1
+++ b/test/ps1/Run-Tests.ps1
@@ -24,7 +24,6 @@ param(
     [Alias("Tags")][string]$Tag = $null,
     [switch]$Strict,
     [switch]$Quiet,
-    [switch]$Fast,
     [switch]$Debug,
     [switch]$TeamCity)
 

--- a/test/ps1/_Common.ps1
+++ b/test/ps1/_Common.ps1
@@ -1,0 +1,56 @@
+function Write-Banner {
+    param($Message)
+
+    Write-Host -ForegroundColor Green "===== $Message ====="
+}
+
+filter Write-CommandOutput {
+    param($Prefix)
+
+    Write-Host -ForegroundColor Magenta -NoNewLine "$($Prefix): "
+    Write-Host $_
+}
+
+$KreVersionRegex = [regex]"(?<ver>\d+\.\d+.\d+)(\-(?<tag>.+))?"
+function Parse-KreVersion {
+    param($Version)
+
+    $m = $KreVersionRegex.Match($Version)
+    if(!$m.Success) {
+        throw "Invalid Version: $Version"
+    }
+
+    New-Object PSObject -Prop @{
+        "Version" = (New-Object Version $m.Groups["ver"].Value)
+        "Tag" = $m.Groups["tag"].Value
+    }
+}
+
+function GetKresOnPath {
+    param($kreHome)
+    if(!$kreHome) {
+        $kreHome = $env:USER_KRE_PATH
+    }
+    @(($env:PATH).Split(";") | Where { $_.StartsWith("$kreHome\packages") })
+}
+
+function GetActiveKrePath {
+    param($kreHome)
+    GetKresOnPath $kreHome | Select -First 1
+}
+
+function GetActiveKreName {
+    param($kreHome)
+    if(!$kreHome) {
+        $kreHome = $env:USER_KRE_PATH
+    }
+    $activeKre = GetActiveKrePath $kreHome
+    if($activeKre) {
+        $activeKre.Replace("$kreHome\packages\", "").Replace("\bin", "")
+    }
+}
+
+function GetKreName {
+    param($clr, $arch, $ver = $testVer)
+    "KRE-$clr-$arch.$testVer"
+}

--- a/test/ps1/_Common.ps1
+++ b/test/ps1/_Common.ps1
@@ -51,6 +51,6 @@ function GetActiveKreName {
 }
 
 function GetKreName {
-    param($clr, $arch, $ver = $testVer)
-    "KRE-$clr-$arch.$testVer"
+    param($clr, $arch, $ver = $TestKreVersion)
+    "KRE-$clr-$arch.$ver"
 }

--- a/test/ps1/_Common.ps1
+++ b/test/ps1/_Common.ps1
@@ -11,21 +11,6 @@ filter Write-CommandOutput {
     Write-Host $_
 }
 
-$KreVersionRegex = [regex]"(?<ver>\d+\.\d+.\d+)(\-(?<tag>.+))?"
-function Parse-KreVersion {
-    param($Version)
-
-    $m = $KreVersionRegex.Match($Version)
-    if(!$m.Success) {
-        throw "Invalid Version: $Version"
-    }
-
-    New-Object PSObject -Prop @{
-        "Version" = (New-Object Version $m.Groups["ver"].Value)
-        "Tag" = $m.Groups["tag"].Value
-    }
-}
-
 function Remove-EnvVar($var) {
     $path = "Env:\$var"
     if(Test-Path $path) {

--- a/test/ps1/_Common.ps1
+++ b/test/ps1/_Common.ps1
@@ -26,6 +26,13 @@ function Parse-KreVersion {
     }
 }
 
+function Remove-EnvVar($var) {
+    $path = "Env:\$var"
+    if(Test-Path $path) {
+        del $path
+    }
+}
+
 function GetKresOnPath {
     param($kreHome)
     if(!$kreHome) {

--- a/test/ps1/_Common.ps1
+++ b/test/ps1/_Common.ps1
@@ -31,7 +31,13 @@ function GetKresOnPath {
     if(!$kreHome) {
         $kreHome = $env:USER_KRE_PATH
     }
-    @(($env:PATH).Split(";") | Where { $_.StartsWith("$kreHome\packages") })
+
+    if($env:PATH) {
+        $paths = $env:PATH.Split(";")
+        if($paths) {
+            @($paths | Where { $_.StartsWith("$kreHome\packages") })
+        }
+    }
 }
 
 function GetActiveKrePath {

--- a/test/ps1/_Execute-Tests.ps1
+++ b/test/ps1/_Execute-Tests.ps1
@@ -29,7 +29,15 @@ if(!$TestsPath) { $TestsPath = Join-Path $PSScriptRoot "tests" }
 if(!$KvmPath) { $KvmPath = Convert-Path (Join-Path $PSScriptRoot "../../src/kvm.ps1") }
 if(!$TestWorkingDir) { $TestWorkingDir = Join-Path $PSScriptRoot ".testwork" }
 if(!$TestAppsDir) { $TestAppsDir = Convert-Path (Join-Path $PSScriptRoot "../apps") }
+
+# Configure the KREs we're going to use in testing. The actual KRE doesn't matter since we're only testing
+# that KVM can find it, download it and unpack it successfully. We do run an app in the KRE to do that sanity
+# test, but all we care about in these tests is that the app executes.
+$env:KRE_NUGET_API_URL = "https://www.myget.org/F/aspnetmaster/api/v2"
 $TestKreVersion = "1.0.0-beta1"
+$specificNupkgUrl = "https://www.myget.org/F/aspnetmaster/api/v2/package/KRE-CLR-x86/1.0.0-alpha4"
+$specificNupkgName = "KRE-CLR-x86.1.0.0-alpha4.nupkg"
+$specificNuPkgFxName = "Asp.Net,Version=v5.0"
 
 # Set up context
 $kvm = $KvmPath
@@ -70,9 +78,6 @@ mkdir $env:USER_KRE_PATH | Out-Null
 $env:GLOBAL_KRE_PATH = "$TestWorkingDir\kre\global"
 mkdir $env:GLOBAL_KRE_PATH | Out-Null
 
-# Configure the NuGet feed URL
-$env:KRE_NUGET_API_URL = "https://www.myget.org/F/aspnetmaster/api/v2"
-
 # Helper function to run kvm and capture stuff.
 $kvmout = $null
 $kvmexit = $null
@@ -93,9 +98,6 @@ function runkvm {
 
 # Fetch a nupkg to use for the 'kvm install <path to nupkg>' scenario
 Write-Banner "Fetching test prerequisites"
-$specificNupkgUrl = "https://www.myget.org/F/aspnetmaster/api/v2/package/KRE-CLR-x86/1.0.0-alpha4"
-$specificNupkgName = "KRE-CLR-x86.1.0.0-alpha4.nupkg"
-$specificNuPkgFxName = "Asp.Net,Version=v5.0"
 
 $downloadDir = Join-Path $TestWorkingDir "downloads"
 if(!(Test-Path $downloadDir)) { mkdir $downloadDir | Out-Null }

--- a/test/ps1/_Execute-Tests.ps1
+++ b/test/ps1/_Execute-Tests.ps1
@@ -131,17 +131,21 @@ if($OutputFile) {
         -PassThru
 }
 
+function TeamCityEscape($str) {
+    $str.Replace("|", "||").Replace("'", "|'").Replace("`n", "|n").Replace("`r", "|r").Replace("[", "|[").Replace("]", "|]")
+}
+
 # Generate TeamCity Output
 if($TeamCity) {
     $result.TestResult | Group-Object Describe | ForEach-Object {
-        $describe = $_.Name
+        $describe = TeamCityEscape $_.Name
         Write-Host "##teamcity[testSuiteStarted name='$describe']"
         $_.Group | Group-Object Context | ForEach-Object {
-            $context = $_.Name
+            $context = TeamCityEscape $_.Name
             Write-Host "##teamcity[testSuiteStarted name='$context']"
             $_.Group | ForEach-Object {
-                $name = "It $($_.Name)"
-                $message = $_.FailureMessage
+                $name = "It $(TeamCityEscape $_.Name)"
+                $message = TeamCityEscape $_.FailureMessage
                 Write-Host "##teamcity[testStarted name='$name']"
                 switch ($_.Result) {
                     Skipped
@@ -154,7 +158,7 @@ if($TeamCity) {
                     }
                     Failed
                     {
-                        Write-Host "##teamcity[testFailed name='$name' message='$message' details='$($_.StackTrace)']"
+                        Write-Host "##teamcity[testFailed name='$name' message='$message' details='$(TeamCityEscape $_.StackTrace)']"
                     }
                 }
                 Write-Host "##teamcity[testFinished name='$name']"

--- a/test/ps1/_Execute-Tests.ps1
+++ b/test/ps1/_Execute-Tests.ps1
@@ -1,0 +1,129 @@
+#Requires -Version 3
+<#
+.SYNOPSIS
+    Runs the tests for kvm
+
+.PARAMETER PesterPath
+    The path to the root of the Pester (https://github.com/pester/Pester) module
+
+.PARAMETER PesterRef
+    A git ref (branch, tag or commit id) to check out in the pester repo
+
+.PARAMETER PesterRepo
+    The repository to clone Pester from (defaults to https://github.com/pester/Pester)
+#>
+param(
+    [string]$PesterPath = $null,
+    [string]$PesterRef = "3.2.0",
+    [string]$PesterRepo = "https://github.com/pester/Pester",
+    [string]$TestsPath = $null,
+    [string]$KvmPath = $null,
+    [string]$TestName = $null,
+    [string]$TestWorkingDir = $null,
+    [string]$TestAppsDir = $null,
+    [Alias("Tags")][string]$Tag = $null,
+    [switch]$Strict,
+    [switch]$Quiet,
+    [switch]$Fast,
+    [switch]$Debug,
+    [switch]$RunningInNewPowershell)
+
+if(!$RunningInNewPowershell) {
+    throw "Don't use this script to run the tests! Use Run-Tests.ps1, it sets up a new powershell instance in which to run the tests!"
+}
+
+. "$PSScriptRoot\_Common.ps1"
+
+Write-Banner "In child shell"
+
+# Check for commands
+if(!(Get-Command git -ErrorAction SilentlyContinue)) { throw "Need git to run tests!" }
+
+# Set defaults
+if(!$PesterPath) { $PesterPath = Join-Path $PSScriptRoot ".pester" }
+if(!$TestsPath) { $TestsPath = Join-Path $PSScriptRoot "tests" }
+if(!$KvmPath) { $KvmPath = Convert-Path (Join-Path $PSScriptRoot "../../src/kvm.ps1") }
+if(!$TestWorkingDir) { $TestWorkingDir = Join-Path $PSScriptRoot ".testwork" }
+if(!$TestAppsDir) { $TestAppsDir = Convert-Path (Join-Path $PSScriptRoot "../apps") }
+
+# Check that Pester is present
+Write-Banner "Ensuring Pester is at $PesterRef"
+if(!(Test-Path $PesterPath)) {
+    git clone $PesterRepo $PesterPath 2>&1 | Write-CommandOutput "git"
+}
+
+# Get the right tag checked out
+pushd $PesterPath
+git checkout $PesterRef 2>&1 | Write-CommandOutput "git"
+popd
+
+# Set up context
+$kvm = $KvmPath
+
+Write-Host "Using kvm: $kvm"
+
+# Create test area
+if(Test-Path "$TestWorkingDir\kre") {
+    Write-Banner "Wiping old test working area"
+    del -rec -for "$TestWorkingDir\kre"
+}
+else {
+    mkdir $TestWorkingDir | Out-Null
+}
+
+# Import the module and set up test environment
+Import-Module "$PesterPath\Pester.psm1"
+
+if($Debug) {
+    $oldDebugPreference = $DebugPreference
+    $DebugPreference = "Continue"
+}
+
+# Unset KRE_HOME for the test
+$oldKreHome = $env:KRE_HOME
+del env:\KRE_HOME
+
+# Unset KRE_TRACE for the test
+del env:\KRE_TRACE
+
+$env:USER_KRE_PATH = "$TestWorkingDir\kre\user"
+mkdir $env:USER_KRE_PATH | Out-Null
+
+$env:GLOBAL_KRE_PATH = "$TestWorkingDir\kre\global"
+mkdir $env:GLOBAL_KRE_PATH | Out-Null
+
+$env:KRE_NUGET_API_URL = "https://www.myget.org/F/aspnetmaster/api/v2"
+
+$TestKind = "all"
+if($Fast) {
+    $TestKind = "fast"
+}
+
+$kvmout = $null
+function runkvm {
+    $kvmout = $null
+    & $kvm -AssumeElevated -OutputVariable kvmout -Quiet @args
+    $LASTEXITCODE | Should Be 0
+
+    if($Debug) {
+        $kvmout | Write-CommandOutput kvm
+    }
+
+    # Push the value up a scope
+    Set-Variable kvmout $kvmout -Scope 1
+}
+
+Write-Banner "Fetching test prerequisites"
+$specificNupkgUrl = "https://www.myget.org/F/aspnetmaster/api/v2/package/KRE-CLR-x86/1.0.0-alpha4"
+$specificNupkgName = "KRE-CLR-x86.1.0.0-alpha4.nupkg"
+$specificNuPkgFxName = "Asp.Net,Version=v5.0"
+
+$downloadDir = Join-Path $TestWorkingDir "downloads"
+if(!(Test-Path $downloadDir)) { mkdir $downloadDir | Out-Null }
+$specificNupkgPath = Join-Path $downloadDir $specificNupkgName
+if(!(Test-Path $specificNupkgPath)) {
+    Invoke-WebRequest $specificNupkgUrl -OutFile $specificNupkgPath
+}
+
+Write-Banner "Running $TestKind Pester Tests in $TestsPath"
+Invoke-Pester -Path $TestsPath -TestName $TestName -Tag $Tag -Strict:$Strict -Quiet:$Quiet

--- a/test/ps1/_Execute-Tests.ps1
+++ b/test/ps1/_Execute-Tests.ps1
@@ -126,4 +126,9 @@ if(!(Test-Path $specificNupkgPath)) {
 }
 
 Write-Banner "Running $TestKind Pester Tests in $TestsPath"
-Invoke-Pester -Path $TestsPath -TestName $TestName -Tag $Tag -Strict:$Strict -Quiet:$Quiet
+$result = Invoke-Pester -Path $TestsPath -TestName $TestName -Tag $Tag -Strict:$Strict -Quiet:$Quiet -PassThru
+
+$result.TestResult | ForEach-Object {
+    Write-Host "TODO: Teamcity formatting for this!"
+    "$($_.Describe) $($_.Context) $($_.Name) - $($_.Result)"
+}

--- a/test/ps1/_Execute-Tests.ps1
+++ b/test/ps1/_Execute-Tests.ps1
@@ -81,12 +81,19 @@ if($Debug) {
     $DebugPreference = "Continue"
 }
 
+function Remove-EnvVar($var) {
+    $path = "Env:\$var"
+    if(Test-Path $path) {
+        del $path
+    }
+}
+
 # Unset KRE_HOME for the test
 $oldKreHome = $env:KRE_HOME
-del env:\KRE_HOME
+Remove-EnvVar KRE_HOME
 
 # Unset KRE_TRACE for the test
-del env:\KRE_TRACE
+Remove-EnvVar KRE_TRACE
 
 $env:USER_KRE_PATH = "$TestWorkingDir\kre\user"
 mkdir $env:USER_KRE_PATH | Out-Null

--- a/test/ps1/_Execute-Tests.ps1
+++ b/test/ps1/_Execute-Tests.ps1
@@ -14,8 +14,8 @@
 #>
 param(
     [string]$PesterPath = $null,
-    [string]$PesterRef = "3.2.0",
-    [string]$PesterRepo = "https://github.com/pester/Pester",
+    [string]$PesterRef = "anurse/teamcity",
+    [string]$PesterRepo = "https://github.com/anurse/Pester",
     [string]$TestsPath = $null,
     [string]$KvmPath = $null,
     [string]$TestName = $null,
@@ -26,7 +26,8 @@ param(
     [switch]$Quiet,
     [switch]$Fast,
     [switch]$Debug,
-    [switch]$RunningInNewPowershell)
+    [switch]$RunningInNewPowershell,
+    [switch]$TeamCity)
 
 if(!$RunningInNewPowershell) {
     throw "Don't use this script to run the tests! Use Run-Tests.ps1, it sets up a new powershell instance in which to run the tests!"
@@ -67,7 +68,8 @@ if(Test-Path "$TestWorkingDir\kre") {
     Write-Banner "Wiping old test working area"
     del -rec -for "$TestWorkingDir\kre"
 }
-else {
+
+if(!(Test-Path $TestWorkingDir)) {
     mkdir $TestWorkingDir | Out-Null
 }
 
@@ -126,9 +128,6 @@ if(!(Test-Path $specificNupkgPath)) {
 }
 
 Write-Banner "Running $TestKind Pester Tests in $TestsPath"
-$result = Invoke-Pester -Path $TestsPath -TestName $TestName -Tag $Tag -Strict:$Strict -Quiet:$Quiet -PassThru
+$result = Invoke-Pester -Path $TestsPath -TestName $TestName -Tag $Tag -Strict:$Strict -Quiet:$Quiet -TeamCity:$TeamCity -PassThru
 
-$result.TestResult | ForEach-Object {
-    Write-Host "TODO: Teamcity formatting for this!"
-    "$($_.Describe) $($_.Context) $($_.Name) - $($_.Result)"
-}
+$host.SetShouldExit($result.FailedCount)

--- a/test/ps1/_Execute-Tests.ps1
+++ b/test/ps1/_Execute-Tests.ps1
@@ -84,6 +84,9 @@ Remove-EnvVar KRE_HOME
 # Unset KRE_TRACE for the test
 Remove-EnvVar KRE_TRACE
 
+# Unset PATH ... gulp
+Remove-EnvVar PATH
+
 $env:USER_KRE_PATH = "$TestWorkingDir\kre\user"
 mkdir $env:USER_KRE_PATH | Out-Null
 
@@ -96,7 +99,7 @@ $kvmout = $null
 $kvmexit = $null
 function runkvm {
     $kvmout = $null
-    & $kvm -AssumeElevated -OutputVariable kvmout -Quiet @args
+    & $kvm -AssumeElevated -OutputVariable kvmout -Quiet @args -ErrorVariable kvmerr -ErrorAction SilentlyContinue
     $kvmexit = $LASTEXITCODE
     
     if($Debug) {
@@ -106,6 +109,7 @@ function runkvm {
     # Push the values up a scope
     Set-Variable kvmout $kvmout -Scope 1
     Set-Variable kvmexit $kvmexit -Scope 1
+    Set-Variable kvmerr $kvmerr -Scope 1
 }
 
 Write-Banner "Fetching test prerequisites"
@@ -120,7 +124,7 @@ if(!(Test-Path $specificNupkgPath)) {
     Invoke-WebRequest $specificNupkgUrl -OutFile $specificNupkgPath
 }
 
-Write-Banner "Running all Pester Tests in $TestsPath"
+Write-Banner "Running Pester Tests in $TestsPath"
 $result = Invoke-Pester -Path $TestsPath -TestName $TestName -Tag $Tag -Strict:$Strict -Quiet:$Quiet -TeamCity:$TeamCity -PassThru
 
 $host.SetShouldExit($result.FailedCount)

--- a/test/ps1/_Execute-Tests.ps1
+++ b/test/ps1/_Execute-Tests.ps1
@@ -132,7 +132,9 @@ if($OutputFile) {
 }
 
 function TeamCityEscape($str) {
-    $str.Replace("|", "||").Replace("'", "|'").Replace("`n", "|n").Replace("`r", "|r").Replace("[", "|[").Replace("]", "|]")
+    if($str) {
+        $str.Replace("|", "||").Replace("'", "|'").Replace("`n", "|n").Replace("`r", "|r").Replace("[", "|[").Replace("]", "|]")
+    }
 }
 
 # Generate TeamCity Output

--- a/test/ps1/_Execute-Tests.ps1
+++ b/test/ps1/_Execute-Tests.ps1
@@ -9,6 +9,8 @@ param(
     [string]$TestWorkingDir = $null,
     [string]$TestAppsDir = $null,
     [Alias("Tags")][string]$Tag = $null,
+    [string]$OutputFile = $null,
+    [string]$OutputFormat = $null,
     [switch]$Strict,
     [switch]$Quiet,
     [switch]$Debug,
@@ -109,7 +111,15 @@ if(!(Test-Path $specificNupkgPath)) {
 # Run the tests!
 
 Write-Banner "Running Pester Tests in $TestsPath"
-$result = Invoke-Pester -Path $TestsPath -TestName $TestName -Tag $Tag -Strict:$Strict -Quiet:$Quiet -TeamCity:$TeamCity -PassThru
+$result = Invoke-Pester `
+    -Path $TestsPath `
+    -TestName $TestName `
+    -Tag $Tag `
+    -Strict:$Strict `
+    -Quiet:$Quiet `
+    -OutputFile $OutputFile `
+    -OutputFormat $OutputFormat `
+    -PassThru
 
 # Set the exit code!
 

--- a/test/ps1/_Execute-Tests.ps1
+++ b/test/ps1/_Execute-Tests.ps1
@@ -23,11 +23,6 @@ if(!$RunningInNewPowershell) {
 
 . "$PSScriptRoot\_Common.ps1"
 
-Write-Banner "In child shell"
-
-# Check for necessary commands
-if(!(Get-Command git -ErrorAction SilentlyContinue)) { throw "Need git to run tests!" }
-
 # Set defaults
 if(!$PesterPath) { $PesterPath = Join-Path $PSScriptRoot ".pester" }
 if(!$TestsPath) { $TestsPath = Join-Path $PSScriptRoot "tests" }
@@ -35,17 +30,6 @@ if(!$KvmPath) { $KvmPath = Convert-Path (Join-Path $PSScriptRoot "../../src/kvm.
 if(!$TestWorkingDir) { $TestWorkingDir = Join-Path $PSScriptRoot ".testwork" }
 if(!$TestAppsDir) { $TestAppsDir = Convert-Path (Join-Path $PSScriptRoot "../apps") }
 $TestKreVersion = "1.0.0-beta1"
-
-# Check that Pester is present
-Write-Banner "Ensuring Pester is at $PesterRef"
-if(!(Test-Path $PesterPath)) {
-    git clone $PesterRepo $PesterPath 2>&1 | Write-CommandOutput "git"
-}
-
-# Get the right tag checked out
-pushd $PesterPath
-git checkout $PesterRef 2>&1 | Write-CommandOutput "git"
-popd
 
 # Set up context
 $kvm = $KvmPath

--- a/test/ps1/tests/Kvm-Alias.Tests.ps1
+++ b/test/ps1/tests/Kvm-Alias.Tests.ps1
@@ -1,0 +1,63 @@
+# Ensure a KRE has been installed (if the other tests ran first, we're good)
+runkvm install $TestKreVersion -arch "x86" -r "CLR"
+
+$notRealKreVersion = "0.0.1-notarealkre"
+
+$kreName = GetKreName "CLR" "x86"
+$notRealKreName = GetKreName "CLR" "x86" $notRealKreVersion
+
+$testAlias = "alias_test_" + [Guid]::NewGuid().ToString("N")
+$notRealAlias = "alias_notReal_" + [Guid]::NewGuid().ToString("N")
+$bogusAlias = "alias_bogus_" + [Guid]::NewGuid().ToString("N")
+        
+Describe "kvm alias" -Tag "kvm-alias" {
+    Context "When defining an alias for a KRE that exists" {
+        runkvm alias $testAlias $TestKreVersion -x86 -r CLR
+        
+        It "writes the alias file" {
+            "$env:USER_KRE_PATH\alias\$testAlias.txt" | Should Exist
+            "$env:USER_KRE_PATH\alias\$testAlias.txt" | Should ContainExactly $kreName
+        }
+    }
+
+    Context "When defining an alias for a KRE that does not exist" {
+        runkvm alias $notRealAlias $notRealKreVersion -x86 -r CLR
+        
+        It "writes the alias file" {
+            "$env:USER_KRE_PATH\alias\$notRealAlias.txt" | Should Exist
+            "$env:USER_KRE_PATH\alias\$notRealAlias.txt" | Should ContainExactly $notRealKreName   
+        }
+    }
+
+    Context "When displaying an alias" {
+        runkvm alias $testAlias
+        It "outputs the value of the alias" {
+            $kvmout[0] | Should Be "Alias '$testAlias' is set to $kreName"
+        }
+    }
+
+    Context "When given an non-existant alias" {
+        runkvm alias $bogusAlias
+        
+        It "outputs an error" {
+            $kvmout[0] | Should Be "Alias '$bogusAlias' does not exist"
+        }
+
+        It "returns a non-zero exit code" {
+            $kvmexit | Should Not Be 0
+        }
+    }
+
+    Context "When displaying all aliases" {
+        $allAliases = runkvm alias | Out-String
+        
+        It "lists all aliases in the alias files" {
+            dir "$env:USER_KRE_PATH\alias\*.txt" | ForEach-Object {
+                $alias = [Regex]::Escape([IO.Path]::GetFileNameWithoutExtension($_.Name))
+                $val = [Regex]::Escape((Get-Content $_))
+
+                $allAliases | Should Match ".*$alias\s+$val.*"
+            }
+        }
+    }
+}

--- a/test/ps1/tests/Kvm-Alias.Tests.ps1
+++ b/test/ps1/tests/Kvm-Alias.Tests.ps1
@@ -61,3 +61,25 @@ Describe "kvm alias" -Tag "kvm-alias" {
         }
     }
 }
+
+Describe "kvm unalias" -Tag "kvm-alias" {
+    Context "When removing an alias that does not exist" {
+        runkvm unalias $bogusAlias
+
+        It "outputs an error" {
+            $kvmout[0] | Should Be "Cannot remove alias, '$bogusAlias' is not a valid alias name"
+        }
+
+        It "returns a non-zero exit code" {
+            $kvmexit | Should Not Be 0
+        }
+    }
+
+    Context "When removing an alias that does exist" {
+        runkvm unalias $testAlias
+
+        It "removes the alias file" {
+            "$env:USER_KRE_PATH\alias\$testAlias.txt" | Should Not Exist
+        }
+    }
+}

--- a/test/ps1/tests/Kvm-Alias.Tests.ps1
+++ b/test/ps1/tests/Kvm-Alias.Tests.ps1
@@ -7,6 +7,7 @@ $kreName = GetKreName "CLR" "x86"
 $notRealKreName = GetKreName "CLR" "x86" $notRealKreVersion
 
 $testAlias = "alias_test_" + [Guid]::NewGuid().ToString("N")
+$testDefaultAlias = "alias_testDefault_" + [Guid]::NewGuid().ToString("N")
 $notRealAlias = "alias_notReal_" + [Guid]::NewGuid().ToString("N")
 $bogusAlias = "alias_bogus_" + [Guid]::NewGuid().ToString("N")
 
@@ -17,6 +18,15 @@ Describe "kvm alias" -Tag "kvm-alias" {
         It "writes the alias file" {
             "$env:USER_KRE_PATH\alias\$testAlias.txt" | Should Exist
             "$env:USER_KRE_PATH\alias\$testAlias.txt" | Should ContainExactly $kreName
+        }
+    }
+
+    Context "When defining an alias for a KRE with no arch or clr parameters" {
+        runkvm alias $testDefaultAlias $TestKreVersion
+
+        It "writes the x86/CLR variant to the alias file" {
+            "$env:USER_KRE_PATH\alias\$testDefaultAlias.txt" | Should Exist
+            "$env:USER_KRE_PATH\alias\$testDefaultAlias.txt" | Should ContainExactly $kreName   
         }
     }
 

--- a/test/ps1/tests/Kvm-Alias.Tests.ps1
+++ b/test/ps1/tests/Kvm-Alias.Tests.ps1
@@ -11,7 +11,7 @@ $testDefaultAlias = "alias_testDefault_" + [Guid]::NewGuid().ToString("N")
 $notRealAlias = "alias_notReal_" + [Guid]::NewGuid().ToString("N")
 $bogusAlias = "alias_bogus_" + [Guid]::NewGuid().ToString("N")
 
-Describe "kvm.ps1 alias" -Tag "kvm-alias" {
+Describe "kvm-ps1 alias" -Tag "kvm-alias" {
     Context "When defining an alias for a KRE that exists" {
         runkvm alias $testAlias $TestKreVersion -x86 -r CLR
         
@@ -66,13 +66,14 @@ Describe "kvm.ps1 alias" -Tag "kvm-alias" {
                 $alias = [Regex]::Escape([IO.Path]::GetFileNameWithoutExtension($_.Name))
                 $val = [Regex]::Escape((Get-Content $_))
 
-                $allAliases | Should Match ".*$alias\s+$val.*"
+                # On some consoles, the value of the alias gets cut off, so don't require it in the assertion.
+                $allAliases | Should Match ".*$alias.*"
             }
         }
     }
 }
 
-Describe "kvm.ps1 unalias" -Tag "kvm-alias" {
+Describe "kvm-ps1 unalias" -Tag "kvm-alias" {
     Context "When removing an alias that does not exist" {
         runkvm unalias $bogusAlias
 

--- a/test/ps1/tests/Kvm-Alias.Tests.ps1
+++ b/test/ps1/tests/Kvm-Alias.Tests.ps1
@@ -11,7 +11,7 @@ $testDefaultAlias = "alias_testDefault_" + [Guid]::NewGuid().ToString("N")
 $notRealAlias = "alias_notReal_" + [Guid]::NewGuid().ToString("N")
 $bogusAlias = "alias_bogus_" + [Guid]::NewGuid().ToString("N")
 
-Describe "kvm alias" -Tag "kvm-alias" {
+Describe "kvm.ps1 alias" -Tag "kvm-alias" {
     Context "When defining an alias for a KRE that exists" {
         runkvm alias $testAlias $TestKreVersion -x86 -r CLR
         
@@ -72,7 +72,7 @@ Describe "kvm alias" -Tag "kvm-alias" {
     }
 }
 
-Describe "kvm unalias" -Tag "kvm-alias" {
+Describe "kvm.ps1 unalias" -Tag "kvm-alias" {
     Context "When removing an alias that does not exist" {
         runkvm unalias $bogusAlias
 

--- a/test/ps1/tests/Kvm-Alias.Tests.ps1
+++ b/test/ps1/tests/Kvm-Alias.Tests.ps1
@@ -9,7 +9,7 @@ $notRealKreName = GetKreName "CLR" "x86" $notRealKreVersion
 $testAlias = "alias_test_" + [Guid]::NewGuid().ToString("N")
 $notRealAlias = "alias_notReal_" + [Guid]::NewGuid().ToString("N")
 $bogusAlias = "alias_bogus_" + [Guid]::NewGuid().ToString("N")
-        
+
 Describe "kvm alias" -Tag "kvm-alias" {
     Context "When defining an alias for a KRE that exists" {
         runkvm alias $testAlias $TestKreVersion -x86 -r CLR

--- a/test/ps1/tests/Kvm-Install.Tests.ps1
+++ b/test/ps1/tests/Kvm-Install.Tests.ps1
@@ -86,7 +86,7 @@ function DefineInstallTests($clr, $arch, [switch]$global, [switch]$noNative) {
     }
 }
 
-Describe "kvm.ps1 install" -Tag "kvm-install" {
+Describe "kvm-ps1 install" -Tag "kvm-install" {
     try {
         DefineInstallTests "CLR" "x86"
         DefineInstallTests "CLR" "amd64"

--- a/test/ps1/tests/Kvm-Install.Tests.ps1
+++ b/test/ps1/tests/Kvm-Install.Tests.ps1
@@ -94,6 +94,18 @@ Describe "kvm install" -Tag "kvm-install" {
         DefineInstallTests "CoreCLR" "amd64"
         DefineInstallTests "CLR" "x86" -global
 
+        Context "When installing a non-existant KRE version" {
+            runkvm install "0.0.1-thisisnotarealKRE"
+
+            It "returns a non-zero exit code" {
+                $kvmexit | Should Not Be 0
+            }
+
+            It "throws a 404 error" {
+                $kvmerr[0].Exception.Message | Should Be 'Exception calling "DownloadFile" with "2" argument(s): "The remote server returned an error: (404) Not Found."'
+            }
+        }
+
         Context "When no architecture is specified" {
             runkvm install $TestKreVersion -r CLR
             $kreName = GetKreName -clr CLR -arch x86
@@ -110,6 +122,15 @@ Describe "kvm install" -Tag "kvm-install" {
             It "uses CLR" {
                 $kvmout[0] | Should Be "$kreName already installed."
             }
+        }
+
+        Context "When neither architecture no runtime is specified" {
+            runkvm install $TestKreVersion
+            $kreName = GetKreName -clr CLR -arch x86
+
+            It "uses x86/CLR" {
+                $kvmout[0] | Should Be "$kreName already installed."
+            }   
         }
 
         Context "When installing latest" {

--- a/test/ps1/tests/Kvm-Install.Tests.ps1
+++ b/test/ps1/tests/Kvm-Install.Tests.ps1
@@ -86,7 +86,7 @@ function DefineInstallTests($clr, $arch, [switch]$global, [switch]$noNative) {
     }
 }
 
-Describe "kvm install" -Tag "kvm-install" {
+Describe "kvm.ps1 install" -Tag "kvm-install" {
     try {
         DefineInstallTests "CLR" "x86"
         DefineInstallTests "CLR" "amd64"

--- a/test/ps1/tests/Kvm-Install.Tests.ps1
+++ b/test/ps1/tests/Kvm-Install.Tests.ps1
@@ -1,0 +1,128 @@
+$testVer = "1.0.0-beta1"
+$archs=@("x86", "amd64")    # List of architectures to test
+$clrs=@("CLR", "CoreCLR")   # List of runtimes to test
+$crossgenned=@("mscorlib")  # List of assemblies to check native images for on CoreCLR
+
+# We can't put Tags on "Context" in Pester, only "Describe" so use this $Fast variable to skip other archs/clrs
+if($Fast) {
+    $archs=@("x86")
+    $clrs=@("CLR")
+}
+
+function DefineInstallTests($clr, $arch, [switch]$global) {
+    $kreHome = $env:USER_KRE_PATH
+    $contextName = "for user"
+    $alias = "install_test_$arch_$clr"
+
+    if($global) {
+        $contextName = "globally"
+        $alias = "global_$alias"
+        $kreHome = $env:GLOBAL_KRE_PATH
+    }
+
+    if($clr -eq "CoreCLR") {
+        $fxName = "Asp.NetCore,Version=v5.0"
+    } else {
+        $fxName = "Asp.Net,Version=v5.0"
+    }    
+
+    $kreName = GetKreName $clr $arch
+    $kreRoot = "$kreHome\packages\$kreName"
+
+    Context "When installing $clr on $arch $contextName" {
+        It "downloads and unpacks a KRE" {
+            if($global) {
+                runkvm install $testVer -arch $arch -r $clr -a $alias -global
+            } else {
+                runkvm install $testVer -arch $arch -r $clr -a $alias
+            }
+        }
+        It "installs the KRE into the user directory" {
+            $kreRoot | Should Exist
+        }
+        if($clr -eq "CoreCLR") {
+            It "crossgenned native assemblies" {
+                $crossgenned | ForEach-Object { "$kreRoot\bin\$_.ni.dll" } | Should Exist
+            }
+        }
+        It "can restore packages for the HelloK sample" {
+            pushd "$TestAppsDir\HelloK"
+            try {
+                & "$kreRoot\bin\kpm.cmd" restore
+            } finally {
+                popd
+            }
+        }
+        It "can run the HelloK sample" {
+            pushd "$TestAppsDir\HelloK"
+            try {
+                $output = & "$kreRoot\bin\k.cmd" run
+                $LASTEXITCODE | Should Be 0
+                $fullOutput = [String]::Join("`r`n", $output)
+
+                $fullOutput | Should Match "K is sane!"
+                $fullOutput | Should Match "Runtime Framework:\s+$fxName"
+            } finally {
+                popd
+            }
+        }
+        It "assigned the requested alias" {
+            "$env:USER_KRE_PATH\alias\$alias.txt" | Should Exist
+            "$env:USER_KRE_PATH\alias\$alias.txt" | Should ContainExactly $kreName
+        }
+        It "uses the new KRE" {
+            GetActiveKreName $kreHome | Should Be "$kreName"
+        }
+    }
+}
+
+Describe "Kvm-Install" {
+    $archs | ForEach-Object {
+        $arch = $_
+        $clrs | ForEach-Object {
+            $clr = $_
+            DefineInstallTests $clr $arch
+            DefineInstallTests $clr $arch -global
+        }
+    }
+
+    Context "When installing latest" {
+        $previous = @(dir "$env:USER_KRE_PATH\packages" | select -ExpandProperty Name)
+        It "downloads a KRE" {
+            runkvm install latest -arch x86 -r CLR
+        }
+        # TODO: Check that it actually installed the latest?
+    }
+
+    Context "When installing an already-installed KRE" {
+        # Clear active KRE
+        runkvm use none
+
+        $kreName = GetKreName $clrs[0] $archs[0]
+        $krePath = "$env:USER_KRE_PATH\packages\$kreName"
+        It "ensures the KRE is installed" {
+            runkvm install $testVer -arch $archs[0] -r $clrs[0]
+            $kvmout[0] | Should Match "$kreName already installed"
+            $krePath | Should Exist
+        }
+    }
+
+    Context "When installing a specific nupkg" {
+        $name = [IO.Path]::GetFileNameWithoutExtension($specificNupkgName)
+        $kreRoot = "$env:USER_KRE_PATH\packages\$name"
+
+        It "unpacks the KRE" {
+            runkvm install $specificNupkgPath
+        }
+        
+        It "installs the KRE into the user directory" {
+            $kreRoot | Should Exist
+        }
+
+        It "did not assign an alias" {
+            dir "$env:USER_KRE_PATH\alias\*.txt" | ForEach-Object {
+                $_ | Should Not Contain $name
+            }
+        }
+    }
+}

--- a/test/ps1/tests/Kvm-Use.Tests.ps1
+++ b/test/ps1/tests/Kvm-Use.Tests.ps1
@@ -31,17 +31,20 @@ Describe "kvm-ps1 use" -Tag "kvm-use" {
 
         It "puts K on the PATH" {
             $cmd = Get-Command k
-            $cmd.Source | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\k.cmd")
+            $cmd | Should Not BeNullOrEmpty
+            $cmd.Definition | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\k.cmd")
         }
 
         It "puts kpm on the PATH" {
             $cmd = Get-Command kpm
-            $cmd.Source | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\kpm.cmd")
+            $cmd | Should Not BeNullOrEmpty
+            $cmd.Definition | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\kpm.cmd")
         }
 
         It "puts klr on the PATH" {
             $cmd = Get-Command klr
-            $cmd.Source | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\klr.exe")
+            $cmd | Should Not BeNullOrEmpty
+            $cmd.Definition | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\klr.exe")
         }
 
         runkvm use none
@@ -55,17 +58,20 @@ Describe "kvm-ps1 use" -Tag "kvm-use" {
 
         It "puts K on the PATH" {
             $cmd = Get-Command k
-            $cmd.Source | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\k.cmd")
+            $cmd | Should Not BeNullOrEmpty
+            $cmd.Definition | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\k.cmd")
         }
 
         It "puts kpm on the PATH" {
             $cmd = Get-Command kpm
-            $cmd.Source | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\kpm.cmd")
+            $cmd | Should Not BeNullOrEmpty
+            $cmd.Definition | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\kpm.cmd")
         }
 
         It "puts klr on the PATH" {
             $cmd = Get-Command klr
-            $cmd.Source | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\klr.exe")
+            $cmd | Should Not BeNullOrEmpty
+            $cmd.Definition | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\klr.exe")
         }
     }
 

--- a/test/ps1/tests/Kvm-Use.Tests.ps1
+++ b/test/ps1/tests/Kvm-Use.Tests.ps1
@@ -1,0 +1,107 @@
+# Ensure some KREs have been installed (if the other tests ran first, we're good)
+runkvm install $TestKreVersion -arch "x86" -r "CLR"
+
+$notRealKreVersion = "0.0.1-notarealkre"
+
+$kreName = GetKreName "CLR" "x86"
+$notRealKreName = GetKreName "CLR" "x86" $notRealKreVersion
+
+$testAlias = "use_test_" + [Guid]::NewGuid().ToString("N")
+$notRealAlias = "use_notReal_" + [Guid]::NewGuid().ToString("N")
+$bogusAlias = "use_bogus_" + [Guid]::NewGuid().ToString("N")
+
+runkvm alias $testAlias $TestKreVersion -arch "x86" -r "CLR"
+runkvm use none
+        
+Describe "kvm use" -Tag "kvm-use" {
+    Context "When use-ing without a runtime or architecture" {
+        runkvm use $TestKreVersion
+        $kreName = GetKreName -clr CLR -arch x86
+
+        It "uses x86/CLR variant" {
+            GetActiveKreName | Should Be $kreName
+        }
+
+        runkvm use none
+    }
+
+    Context "When use-ing a KRE" {
+        runkvm use $TestKreVersion
+        $kreName = GetKreName -clr CLR -arch x86
+
+        It "puts K on the PATH" {
+            $cmd = Get-Command k
+            $cmd.Source | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\k.cmd")
+        }
+
+        It "puts kpm on the PATH" {
+            $cmd = Get-Command kpm
+            $cmd.Source | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\kpm.cmd")
+        }
+
+        It "puts klr on the PATH" {
+            $cmd = Get-Command klr
+            $cmd.Source | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\klr.exe")
+        }
+
+        runkvm use none
+    }
+
+    Context "When use-ing an alias" {
+        # Sanity check assumptions
+        Get-Command k -ErrorAction SilentlyContinue | Should BeNullOrEmpty
+
+        runkvm use $testAlias
+
+        It "puts K on the PATH" {
+            $cmd = Get-Command k
+            $cmd.Source | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\k.cmd")
+        }
+
+        It "puts kpm on the PATH" {
+            $cmd = Get-Command kpm
+            $cmd.Source | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\kpm.cmd")
+        }
+
+        It "puts klr on the PATH" {
+            $cmd = Get-Command klr
+            $cmd.Source | Should Be (Convert-Path "$env:USER_KRE_PATH\packages\$kreName\bin\klr.exe")
+        }
+    }
+
+    Context "When use-ing 'none'" {
+        runkvm use $TestKreVersion
+        
+        runkvm use none
+
+        It "removes the KRE from the PATH" {
+            GetKresOnPath | Should BeNullOrEmpty
+        }
+
+        It "removes K from the PATH" {
+            (Get-Command k -ErrorAction SilentlyContinue) | Should BeNullOrEmpty
+        }
+
+        It "removes kpm from the PATH" {
+            (Get-Command kpm -ErrorAction SilentlyContinue) | Should BeNullOrEmpty
+        }
+
+        It "removes klr from the PATH" {
+            (Get-Command klr -ErrorAction SilentlyContinue) | Should BeNullOrEmpty
+        }
+    }
+
+    Context "When use-ing a non-existant version" {
+        It "should throw an error" {
+            runkvm use $notRealKreVersion
+            $kvmerr[0].Exception.Message | Should Be "Cannot find $notRealKreName, do you need to run 'kvm install $notRealKreVersion'?"
+        }
+    }
+
+    Context "When use-ing a non-existant alias" {
+        It "should throw an error" {
+            runkvm use "bogus_alias_that_does_not_exist"
+            $kvmerr[0].Exception.Message | Should Be "Cannot find KRE-CLR-x86.bogus_alias_that_does_not_exist, do you need to run 'kvm install bogus_alias_that_does_not_exist'?"
+        }
+    }
+}

--- a/test/ps1/tests/Kvm-Use.Tests.ps1
+++ b/test/ps1/tests/Kvm-Use.Tests.ps1
@@ -13,7 +13,7 @@ $bogusAlias = "use_bogus_" + [Guid]::NewGuid().ToString("N")
 runkvm alias $testAlias $TestKreVersion -arch "x86" -r "CLR"
 runkvm use none
         
-Describe "kvm.ps1 use" -Tag "kvm-use" {
+Describe "kvm-ps1 use" -Tag "kvm-use" {
     Context "When use-ing without a runtime or architecture" {
         runkvm use $TestKreVersion
         $kreName = GetKreName -clr CLR -arch x86

--- a/test/ps1/tests/Kvm-Use.Tests.ps1
+++ b/test/ps1/tests/Kvm-Use.Tests.ps1
@@ -13,7 +13,7 @@ $bogusAlias = "use_bogus_" + [Guid]::NewGuid().ToString("N")
 runkvm alias $testAlias $TestKreVersion -arch "x86" -r "CLR"
 runkvm use none
         
-Describe "kvm use" -Tag "kvm-use" {
+Describe "kvm.ps1 use" -Tag "kvm-use" {
     Context "When use-ing without a runtime or architecture" {
         runkvm use $TestKreVersion
         $kreName = GetKreName -clr CLR -arch x86


### PR DESCRIPTION
Added a bunch of automated tests using [Pester](https://github.com/Pester/Pester).

Note: I needed to patch Pester to write marker strings to stdout for TeamCity to read (as per https://confluence.jetbrains.com/display/TCD9/Build+Script+Interaction+with+TeamCity). The patch is in a personal fork of Pester.

It's all integrated into the makefile, so it works on the CI and reports detailed test failure information to the Tests tab for the build on TeamCity.

There are a couple scenarios that are not covered (they involved a lot more machine-level config I didn't want to mess with in automated tests):
* Installation of kvm.ps1 itself
* kvm use -persistent