### PR TITLE
Fixing regression in curl command

### DIFF
--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -83,7 +83,7 @@ _kvm_download() {
 
     mkdir -p "$kreFolder" > /dev/null 2>&1
 
-    local httpResult=$(curl -L -D "$url" -o "$kreFile" 2>/dev/null | grep "^HTTP/1.1" | head -n 1 | sed "s/HTTP.1.1 \([0-9]*\).*/\1/")
+    local httpResult=$(curl -L -D - "$url" -o "$kreFile" 2>/dev/null | grep "^HTTP/1.1" | head -n 1 | sed "s/HTTP.1.1 \([0-9]*\).*/\1/")
 
     [[ $httpResult == "404" ]] && echo "$kreFullName was not found in repository $KRE_FEED" && return 1
     [[ $httpResult != "302" && $httpResult != "200" ]] && echo "HTTP Error $httpResult fetching $kreFullName from $KRE_FEED" && return 1


### PR DESCRIPTION
While making the below fix I accidentally removed the '-' parameter value being passed to the '-D' switch of curl command.
https://github.com/aspnet/kvm/commit/0656aeeab37383be661e2a6e0ddbf3252e409f86

'-D' indicates that the headers be written to a file. Adding the '-' back.

@Eilon 