### PR TITLE
Fixing kvm-Global-upgrade

### DIFF
--- a/src/kvm.ps1
+++ b/src/kvm.ps1
@@ -149,14 +149,7 @@ function Kvm-Global-Setup {
 function Kvm-Global-Upgrade {
   $Persistent = $true
   $Alias="default"
-  $versionOrAlias = Kvm-Find-Latest $selectedRuntime $selectedArch
-  If (Needs-Elevation) {
-    $arguments = "-ExecutionPolicy unrestricted & '$scriptPath' install '$versionOrAlias' -global $(Requested-Switches) -wait"
-    Start-Process "$psHome\powershell.exe" -Verb runAs -ArgumentList $arguments -Wait
-    Kvm-Set-Global-Process-Path $versionOrAlias
-    break
-  }
-  Kvm-Install $versionOrAlias $true
+  Kvm-Install "latest" $true
 }
 
 function Kvm-Upgrade {

--- a/src/kvm.ps1
+++ b/src/kvm.ps1
@@ -146,16 +146,13 @@ function Kvm-Global-Setup {
   [Environment]::SetEnvironmentVariable("KRE_HOME", $machineKreHome, [System.EnvironmentVariableTarget]::Machine)
 }
 
-function Kvm-Global-Upgrade {
-  $Persistent = $true
-  $Alias="default"
-  Kvm-Install "latest" $true
-}
-
 function Kvm-Upgrade {
+param(
+  [boolean] $isGlobal
+)
   $Persistent = $true
   $Alias="default"
-  Kvm-Install "latest" $false
+  Kvm-Install "latest" $isGlobal
 }
 
 function Add-Proxy-If-Specified {
@@ -792,7 +789,7 @@ try {
   if ($Global) {
     switch -wildcard ($Command + " " + $Args.Count) {
       "setup 0"           {Kvm-Global-Setup}
-      "upgrade 0"         {Kvm-Global-Upgrade}
+      "upgrade 0"         {Kvm-Upgrade $true}
       "install 1"         {Kvm-Install $Args[0] $true}
       "use 1"             {Kvm-Global-Use $Args[0]}
       default             {throw "Unknown command, or global switch not supported"};
@@ -800,7 +797,7 @@ try {
   } else {
     switch -wildcard ($Command + " " + $Args.Count) {
       "setup 0"           {Kvm-Global-Setup}
-      "upgrade 0"         {Kvm-Upgrade}
+      "upgrade 0"         {Kvm-Upgrade $false}
       "install 1"         {Kvm-Install $Args[0] $false}
       "list 0"            {Kvm-List}
       "use 1"             {Kvm-Use $Args[0]}


### PR DESCRIPTION
When kvm upgrade is executed with a -g flag, today the code tries to fetch the latest version details from the REST url passing in the selectedRuntime and selectedArch explicitly.

These parameters have null values when this command is executed. Right thing is to have code exactly similar to Kvm-Upgrade but pass on global flag to Kvm-Install. This also avoid duplicate code on (Needs-Elevation) case. I verified this fixes the issue.

Fixes bug: https://github.com/aspnet/kvm/issues/81

@Eilon @muratg 