### PR TITLE
Passing in the right KRE identifier in case of global installs.

### DIFF
--- a/src/kvm.ps1
+++ b/src/kvm.ps1
@@ -311,7 +311,7 @@ param(
     if (Needs-Elevation) {
       $arguments = "-ExecutionPolicy unrestricted & '$scriptPath' install '$versionOrAlias' -global $(Requested-Switches) -wait"
       Start-Process "$psHome\powershell.exe" -Verb runAs -ArgumentList $arguments -Wait
-      Kvm-Set-Global-Process-Path $versionOrAlias
+      Kvm-Use $kreFullName
       break
     }
     $packageFolder = $globalKrePackages
@@ -447,11 +447,11 @@ param(
   If (Needs-Elevation) {
     $arguments = "-ExecutionPolicy unrestricted & '$scriptPath' use '$versionOrAlias' -global $(Requested-Switches) -wait"
     Start-Process "$psHome\powershell.exe" -Verb runAs -ArgumentList $arguments -Wait
-    Kvm-Set-Global-Process-Path $versionOrAlias
+    Kvm-Use $versionOrAlias
     break
   }
 
-  Kvm-Set-Global-Process-Path "$versionOrAlias"
+  Kvm-Use "$versionOrAlias"
 
   if ($versionOrAlias -eq "none") {
     if ($Persistent) {
@@ -475,27 +475,6 @@ param(
     $machinePath = Change-Path $machinePath $kreBin ($globalKrePackages, $userKrePackages)
     [Environment]::SetEnvironmentVariable("Path", $machinePath, [System.EnvironmentVariableTarget]::Machine)
   }
-}
-
-function Kvm-Set-Global-Process-Path {
-param(
-  [string] $versionOrAlias
-)
-  if ($versionOrAlias -eq "none") {
-    Console-Write "Removing KRE from process PATH"
-    Set-Path (Change-Path $env:Path "" ($globalKrePackages, $userKrePackages))
-    return
-  }
-
-  $kreFullName = Requested-VersionOrAlias $versionOrAlias
-  $kreBin = Locate-KreBinFromFullName $kreFullName
-  if ($kreBin -eq $null) {
-    Console-Write "Cannot find $kreFullName, do you need to run 'kvm install $versionOrAlias'?"
-    return
-  }
-
-  Console-Write "Adding $kreBin to process PATH"
-  Set-Path (Change-Path $env:Path $kreBin ($globalKrePackages, $userKrePackages))
 }
 
 function Kvm-Use {


### PR DESCRIPTION
Also find that Kvm-Set-Global-Process-Path is nothing special and it does a subset of what kvm-use does. So removing that and using kvm-use everywhere.

This fix originally started while investigating https://github.com/aspnet/kvm/issues/35. In case of a global install pointing to a .nupkg file, in https://github.com/aspnet/kvm/blob/dev/src/kvm.ps1#L314 we pass in the full path to the nupkg file as a parameter. For example:
while executing command:
kvm install \\\\machinename\drops\Coherence\dev\Latest\build\KRE-CLR-amd64.1.0.0-rc1-10864.nupkg -g
we pass in \\machinename\drops\Coherence\dev\Latest\build\KRE-CLR-amd64.1.0.0-rc1-10864.nupkg as the parameter value to Kvm-Set-Global-Process-Path. Then the

Then the function computes the name of the KRE incorrectly as `KRE-CLR-x86.\\machinename\drops\Coherence\dev\Latest\build\KRE-CLR-amd64.1.0.0-rc1-10864.nupkg` in line https://github.com/aspnet/kvm/blob/dev/src/kvm.ps1#L490 resulting in a failure as listed in the bug even though kvm install is successful as it cannot find such a KRE\bin folder.

The fix is to pass in the KRE name instead of the full path in case of global installs. And removing Kvm-Set-Global-Process-Path which does exactly the same as kvm-use and performs subset.

@graemechristie - could you review this and give your comments? 