### PR TITLE
Fixes #130 by adding a hash check for the test nupkg

### DIFF
--- a/test/ps1/_Common.ps1
+++ b/test/ps1/_Common.ps1
@@ -52,3 +52,25 @@ function GetKreName {
     param($clr, $arch, $ver = $TestKreVersion)
     "KRE-$clr-$arch.$ver"
 }
+
+# Borrowed from kvm itself, but we can't really use that one so unfortunately we have to use copy-pasta :)
+# Modified slightly to take in a Proxy value so that it can be defined separately from the Proxy parameter
+function Add-Proxy-If-Specified {
+param(
+  [System.Net.WebClient] $wc,
+  [string] $Proxy
+)
+  if(!$Proxy) {
+    $Proxy = $env:http_proxy
+  }
+  if ($Proxy) {
+    $wp = New-Object System.Net.WebProxy($Proxy)
+    $pb = New-Object UriBuilder($Proxy)
+    if (!$pb.UserName) {
+        $wp.Credentials = [System.Net.CredentialCache]::DefaultCredentials
+    } else {
+        $wp.Credentials = New-Object System.Net.NetworkCredential($pb.UserName, $pb.Password)
+    }
+    $wc.Proxy = $wp
+  }
+}


### PR DESCRIPTION
@Praburaj and I were seeing some occasional corruption in the nupkg downloaded by the tests for testing `kvm install <nupkgPath>`. It is compounded by the fact that if the file exists with the expected name, the tests never redownload them. So I added a SHA-256 hash check in that ensures the package is valid. It's still possible for the tests to fail due to corruption, but now it should fail early and have a descriptive message. Also, re-running the tests will re-attempt the download.

Fixes #130 