### PR TITLE
Fixing the typo in the command line option -persistant

### DIFF
--- a/src/kvm.sh
+++ b/src/kvm.sh
@@ -202,12 +202,12 @@ kvm()
         "install" )
             [ $# -lt 2 ] && kvm help && return
             shift
-            local persistant=
+            local persistent=
             local versionOrAlias=
             local alias=
             while [ $# -ne 0 ]
             do
-                if [[ $1 == "-p" || $1 == "-persistant" ]]; then
+                if [[ $1 == "-p" || $1 == "-persistent" ]]; then
                     local persistent="-p"
                 elif [[ $1 == "-a" || $1 == "-alias" ]]; then
                     local alias=$2


### PR DESCRIPTION
command line help seems to be good. However the parsed option value seems to be incorrect.

This was reported in bug # https://github.com/aspnet/kvm/issues/89

@anurse 